### PR TITLE
allow 0.7.0 <= flipper version < 1.0.0

### DIFF
--- a/flipper-consul.gemspec
+++ b/flipper-consul.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  
-  spec.add_dependency 'flipper',  '~> 0.7.0'
+
+  spec.add_dependency 'flipper',  '~> 0.7'
   spec.add_dependency 'diplomat', '~> 0.11'
 end


### PR DESCRIPTION
simply lift the patch-lock restriction on 0.7.0 <= flipper version < 0.8.0 so that we can get the latest version of flipper. semantic versioning says any minor version updates should be backwards
compatible.

a quick look at the flipper changelog also suggests this should still be compatible.
